### PR TITLE
Remove gvfs flag

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -11,10 +11,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=home",
-        "--talk-name=org.gtk.vfs",
-        "--talk-name=org.gtk.vfs.*",
         "--metadata=X-DConf=migrate-path=/org/gnome/file-roller/",
-        "--filesystem=xdg-run/gvfs",
         "--own-name=org.gnome.ArchiveManager1"
     ],
     "cleanup": [


### PR DESCRIPTION
It seems this app does not use gvfs.

Fixes: https://github.com/flathub/org.gnome.FileRoller/issues/10