### PR TITLE
p7zip: Set /app install prefix

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -22,6 +22,9 @@
             "make-args": [
                 "7z"
             ],
+            "make-install-args": [
+                "DEST_HOME=/app"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Merged upstream here:
https://gitlab.gnome.org/GNOME/file-roller/-/commit/a29bf6847d09f1c00b8c05f7254a528c95a7266d

The `p7zip` module wasn't actually installing, because it was trying to install to `/usr/local` and failing due to it being read-only.