### PR TITLE
Add x-checker-data metadata for some modules

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -29,7 +29,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/p7zip-project/p7zip/archive/refs/tags/v17.05.tar.gz",
-                    "sha256": "d2788f892571058c08d27095c22154579dfefb807ebe357d145ab2ddddefb1a6"
+                    "sha256": "d2788f892571058c08d27095c22154579dfefb807ebe357d145ab2ddddefb1a6",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/p7zip-project/p7zip/releases/latest",
+                        "version-query": ".tag_name",
+                        "url-query": "\"https://github.com/p7zip-project/p7zip/archive/refs/tags/\\($version).tar.gz\""
+                    }
                 }
             ]
         },
@@ -44,7 +50,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/gnustep/tools-make/archive/refs/tags/make-2_9_1.tar.gz",
-                    "sha256": "78ef0f68402c379979a9a46499ac308fe5c1512aa198138c87649ee611aedf41"
+                    "sha256": "78ef0f68402c379979a9a46499ac308fe5c1512aa198138c87649ee611aedf41",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/gnustep/tools-make/releases/latest",
+                        "version-query": ".tag_name | sub(\"^make-\"; \"\") | gsub(\"_\"; \".\")",
+                        "url-query": ".assets[] | select(.name==\"gnustep-make-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -60,7 +72,13 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/gnustep/libs-base/archive/refs/tags/base-1_29_0.tar.gz",
-                    "sha256": "4dc7272a5c44844b823d31811af6a9f4e3bda04bb78139c0446f03ea4bdb2fd3"
+                    "sha256": "4dc7272a5c44844b823d31811af6a9f4e3bda04bb78139c0446f03ea4bdb2fd3",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/gnustep/libs-base/releases/latest",
+                        "version-query": ".tag_name | sub(\"^base-\"; \"\") | gsub(\"_\"; \".\")",
+                        "url-query": ".assets[] | select(.name==\"gnustep-base-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
                 }
             ]
         },
@@ -88,7 +106,14 @@
                 {
                     "type": "archive",
                     "url": "https://github.com/facebook/zstd/archive/refs/tags/v1.5.4.tar.gz",
-                    "sha256": "35ad983197f8f8eb0c963877bf8be50490a0b3df54b4edeb8399ba8a8b2f60a4"
+                    "sha256": "35ad983197f8f8eb0c963877bf8be50490a0b3df54b4edeb8399ba8a8b2f60a4",
+                    "x-checker-data": {
+                        "type": "json",
+                        "url": "https://api.github.com/repos/facebook/zstd/releases/latest",
+                        "version-query": ".tag_name | sub(\"^v|\"; \"\")",
+                        "url-query": ".assets[] | select(.name==\"zstd-\" + $version + \".tar.gz\") | .browser_download_url"
+                    }
+
                 }
             ]
         },

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -22,6 +22,9 @@
             "make-args": [
                 "7z"
             ],
+            "make-install-args": [
+                "DEST_HOME=/app"
+            ],
             "sources": [
                 {
                     "type": "archive",


### PR DESCRIPTION
Proposed upstream here:
https://gitlab.gnome.org/GNOME/file-roller/-/merge_requests/97

Tested here:
https://github.com/elementary/fileroller/pull/35