### PR TITLE
Switch from p7zip to 7zip

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -18,24 +18,23 @@
     ],
     "modules": [
         {
-            "name": "p7zip",
-            "no-autogen": true,
-            "make-args": [
-                "7z"
-            ],
-            "make-install-args": [
-                "DEST_HOME=/app"
+            "name": "7zip",
+            "buildsystem": "simple",
+            "subdir": "CPP/7zip/Bundles/Alone7z",
+            "build-commands": [
+                "make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc",
+                "install -D ./_o/7zr -t /app/bin",
+                "ln -s /app/bin/7zr /app/bin/7z"
             ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/p7zip-project/p7zip/archive/refs/tags/v17.05.tar.gz",
-                    "sha256": "d2788f892571058c08d27095c22154579dfefb807ebe357d145ab2ddddefb1a6",
+                    "url": "https://github.com/ip7z/7zip/archive/refs/tags/25.00.tar.gz",
+                    "sha256": "81832d14c91206e5d4abdf15d8222cb0824e3cfafc7ee1483ccd2b5929c21f3d",
                     "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/p7zip-project/p7zip/releases/latest",
-                        "version-query": ".tag_name",
-                        "url-query": "\"https://github.com/p7zip-project/p7zip/archive/refs/tags/\\($version).tar.gz\""
+                        "type": "anitya",
+                        "project-id": 372314,
+                        "url-template": "https://github.com/ip7z/7zip/archive/refs/tags/$version.tar.gz"
                     }
                 }
             ]

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -29,8 +29,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/ip7z/7zip/archive/refs/tags/25.00.tar.gz",
-                    "sha256": "81832d14c91206e5d4abdf15d8222cb0824e3cfafc7ee1483ccd2b5929c21f3d",
+                    "url": "https://github.com/ip7z/7zip/archive/refs/tags/25.01.tar.gz",
+                    "sha256": "8772e4ef86540c98bf4c23a6d9e13b3a25794d4bb30986ef0b1b9f20075b34c9",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 372314,
@@ -51,8 +51,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://www.rarlab.com/rar/unrarsrc-7.1.5.tar.gz",
-                    "sha256": "d1acac7ed5b45db587294b357fdd6e74982ce21f5edfcb113c4ca263bc0c666d",
+                    "url": "https://www.rarlab.com/rar/unrarsrc-7.1.10.tar.gz",
+                    "sha256": "72a9ccca146174f41876e8b21ab27e973f039c6d10b13aabcb320e7055b9bb98",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 13306,

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.FileRoller",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "file-roller",
     "finish-args": [

--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -1,7 +1,7 @@
 {
     "id": "org.gnome.FileRoller",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "file-roller",
     "finish-args": [


### PR DESCRIPTION
p7zip-project seems unmaintained and it suffers from a couple of notable unfixed bugs. Over the last couple of years, almost all distros and most Flathub apps have switched to the upstream 7zip, as it started having a Linux version a few years ago.