### PR TITLE
Remove unrar

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -40,28 +40,6 @@
             ]
         },
         {
-            "name": "unrar",
-            "no-autogen": true,
-            "build-options": {
-                "strip": true
-            },
-            "make-install-args": [
-                "DESTDIR=$(FLATPAK_DEST)"
-            ],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://www.rarlab.com/rar/unrarsrc-7.1.10.tar.gz",
-                    "sha256": "72a9ccca146174f41876e8b21ab27e973f039c6d10b13aabcb320e7055b9bb98",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 13306,
-                        "url-template": "https://www.rarlab.com/rar/unrarsrc-$version.tar.gz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "zstd",
             "buildsystem": "meson",
             "subdir": "build/meson",


### PR DESCRIPTION
Opening and extracting RAR5 archives works fine with libarchive from the runtime. The license of RARLAB unrar is proprietary, and there is probably nothing gained from bundling it in the Flatpak.