### PR TITLE
Fix zip support by removing 7z -> 7zr symlink

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -23,8 +23,7 @@
             "subdir": "CPP/7zip/Bundles/Alone7z",
             "build-commands": [
                 "make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc",
-                "install -D ./_o/7zr -t /app/bin",
-                "ln -s /app/bin/7zr /app/bin/7z"
+                "install -D ./_o/7zr -t /app/bin"
             ],
             "sources": [
                 {


### PR DESCRIPTION
I noticed #42 broke support for zip files. It looks like File Roller is trying to open zip files using 7z, as it recognizes 7z as a command that supports many formats, including zip. On the other hand, File Roller recognizes 7zr as a command that supports only 7z files, so removing the 7z symlink makes File Roller play nicely with the 7zr binary included in the flatpak. After this change it uses 7zr for 7z files and reaches for a different tool (zip or libarchive, I suppose) for zip files.

I tested the change locally creating, opening and extracting zip and 7z files and it seems to be working fine.