### PR TITLE
Remove zstd module

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -39,24 +39,6 @@
             ]
         },
         {
-            "name": "zstd",
-            "buildsystem": "meson",
-            "subdir": "build/meson",
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz",
-                    "sha256": "eb33e51f49a15e023950cd7825ca74a4a2b43db8354825ac24fc1b7ee09e6fa3",
-                    "x-checker-data": {
-                        "type": "json",
-                        "url": "https://api.github.com/repos/facebook/zstd/releases/latest",
-                        "version-query": ".tag_name | sub(\"^v|\"; \"\")",
-                        "url-query": ".assets[] | select(.name==\"zstd-\" + $version + \".tar.gz\") | .browser_download_url"
-                    }
-                }
-            ]
-        },
-        {
             "name": "rpm2cpio",
             "buildsystem": "simple",
             "build-commands": [


### PR DESCRIPTION
This is part of the fdo 25.08 runtime.

Fixes: https://github.com/flathub/org.gnome.FileRoller/issues/48