### PR TITLE
Use correct 7-Zip variant

### DIFF
--- a/org.gnome.FileRoller.json
+++ b/org.gnome.FileRoller.json
@@ -22,10 +22,34 @@
         {
             "name": "7zip",
             "buildsystem": "simple",
-            "subdir": "CPP/7zip/Bundles/Alone7z",
+            "subdir": "CPP/7zip/Bundles/Alone2",
+            "build-options" : {
+                "env": {
+                    "makefile": "../../cmpl_gcc.mak"
+                },
+                "arch": {
+                    "aarch64": {
+                        "env": {
+                            "makefile": "../../cmpl_gcc_arm64.mak"
+                        }
+                    },
+                    "i686": {
+                        "env": {
+                            "makeFlags": "USE_ASM=",
+                            "makefile": "../../cmpl_gcc_x86.mak"
+                        }
+                    },
+                    "x86_64": {
+                        "env": {
+                            "makeFlags": "USE_ASM=",
+                            "makefile": "../../cmpl_gcc_x64.mak"
+                        }
+                    }
+                }
+            },
             "build-commands": [
-                "make -j $FLATPAK_BUILDER_N_JOBS -f makefile.gcc",
-                "install -D ./_o/7zr -t /app/bin"
+                "make -j $FLATPAK_BUILDER_N_JOBS -f $makefile $makeFlags",
+                "install -D b/*/7zz -t /app/bin"
             ],
             "sources": [
                 {


### PR DESCRIPTION
6ad5200226e91de8ac01e159dc286cd2688e73b3 replaced p7zip port with the upstream 7-Zip project. Unfortunately, it chose a bundle from `Alone7z` directory (producing `7zr` program), which is reduced and only supports 7z format.

Additionally, since File-Roller [determines the set of supported features based on the file names of available programs](https://gitlab.gnome.org/GNOME/file-roller/-/blob/ab282a8de39a2a3162cba13721eb356b7fc2f490/src/fr-command-7z.c#L703), after the fake `7z` symlink was removed in 19d639d567181a54ec039182eb6b5706e839bdd5, it no longer detected header encryption support.

Let’s switch to the correct bundle from `Alone2` directory that produces the full-featured `7zz` program, as described in the [README](https://github.com/ip7z/7zip/blob/839151eaaad24771892afaae6bac690e31e58384/DOC/readme.txt#L110).

Unfortunately, 7-Zip uses MASM (assembly from Microsoft) on x86 so we need to disable it unless we package [asmc](https://github.com/nidud/asmc). On ARM, it uses assembly supported by gcc so it is fine there.

Upstream change: https://gitlab.gnome.org/GNOME/file-roller/-/commit/071b81579e7fe0bc600bb632587f1b0f97dc26cb
Fixes: https://gitlab.gnome.org/GNOME/file-roller/-/issues/317
